### PR TITLE
#166152809 Admin can delete a posted AD record (CRUD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AutoMart
 AutoMart is an online app that enables you to sell and/or buy cars.
 
-[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-view-unsold-cars-within-range-166152687)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-view-unsold-cars-within-range-166152687)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-view-unsold-cars-within-range-166152687) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
+[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-admin-delete-advert-166152809)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-admin-delete-advert-166152809)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-admin-delete-advert-166152809) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
 
 # Key Application Features
 

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "description": "AutoMart is an online app that enables you to sell and/or buy cars.",
   "main": "app.js",
   "scripts": {
-    "start": "nodemon --exec babel-node app.js",
+    "start:dev": "nodemon --exec babel-node app.js",
     "test": "nyc mocha --require @babel/register --exit --recursive --timeout 40000",
     "coverage": "nyc report --reporter=lcov --reporter=text-lcov | coveralls"
   },
@@ -19,7 +19,8 @@
     "cloudinary": "^1.14.0",
     "connect-multiparty": "^2.2.0",
     "dotenv": "^8.0.0",
-    "express": "^4.17.0"
+    "express": "^4.17.0",
+    "morgan": "^1.9.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/api/server/controllers/CarsController.js
+++ b/api/server/controllers/CarsController.js
@@ -163,6 +163,30 @@ class CarsController {
       });
     }
   }
+
+  deleteCar(req, res) {
+    const carId = req.params.car_id;
+    const validator = new Validator();
+    const validDeleteCarReq = validator.validateDeleteACar(carId);
+    if (validDeleteCarReq.error) {
+      res.status(404).send({
+        status: 404,
+        data: validDeleteCarReq.data,
+      });
+    } else if (!carsService.getCarById(parseInt(carId, 10)).exist) {
+      res.status(404).send({
+        status: 404,
+        error: 'Invalid carId. There is no car with this id.',
+      });
+    } else {
+      const id = parseInt(carId, 10);
+      carsService.delete(id);
+      res.status(200).send({
+        status: 200,
+        data: 'Car Ad successfully deleted',
+      });
+    }
+  }
 }
 
 export default new CarsController();

--- a/api/server/helpers/ValidateCar.js
+++ b/api/server/helpers/ValidateCar.js
@@ -56,6 +56,12 @@ class ValidateCar extends Validator {
     return { error: this.error, data: this.errorMessages };
   }
 
+  // validate the url parameter for car id sent to delete a car
+  validateDeleteACar(carId) {
+    this.validateInt(carId, 'carId');
+    return { error: this.error, data: this.errorMessages };
+  }
+
   isValidOwner(owner, type) {
     this.validateInt(owner, type);
   }

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -1,12 +1,18 @@
 /* eslint-disable linebreak-style */
 import express from 'express';
+import logger from 'morgan';
 import bodyParser from 'body-parser';
 import usersRouter from './routes/usersRoutes';
 import carsRouter from './routes/carsRoutes';
 import ordersRouter from './routes/ordersRoutes';
 
+// Set up express app
 const app = express();
 
+// Log request to console
+app.use(logger('dev'));
+
+// Parse incoming request data
 app.use(bodyParser.json());
 app.use(bodyParser.json({ type: 'application/json' }));
 app.use(bodyParser.urlencoded({ extended: true }));

--- a/api/server/routes/carsRoutes.js
+++ b/api/server/routes/carsRoutes.js
@@ -10,6 +10,7 @@ Router.post('/car', multipartMiddleware, carsControllers.addCar); // add a car
 Router.patch('/car/:car_id/status', carsControllers.updateCarStatus); // update car status
 Router.patch('/car/:car_id/price', carsControllers.updateCarPrice); // update the price of a car
 Router.get('/car/:car_id', carsControllers.getACar); // get a specific car
-Router.get('/car', carsControllers.getCars);
+Router.get('/car', carsControllers.getCars); // get cars
+Router.delete('/car/:car_id', carsControllers.deleteCar); // delete a car
 
 export default Router;

--- a/api/server/services/CarsService.js
+++ b/api/server/services/CarsService.js
@@ -160,6 +160,15 @@ class CarsService {
       status: this.cars[i].status,
     };
   }
+
+  delete(id) {
+    for (let i = 0; i < this.cars.length; i += 1) {
+      if (this.cars[i].id === id) {
+        this.cars.splice(i, 1);
+        break;
+      }
+    }
+  }
 }
 
 export default new CarsService();

--- a/api/test/carsTest.js
+++ b/api/test/carsTest.js
@@ -306,5 +306,38 @@ describe('Cars Test', () => {
           done();
         });
     });
+
+    describe('DELETE /api/v1/car/:car_id', () => {
+      it('should delete a posted car ad', (done) => {
+        chai.request(app)
+          .delete('/api/v1/car/4')
+          .end((err, res) => {
+            expect(res.status).to.be.equal(200);
+            expect(res.type).to.be.equal('application/json');
+            expect(res.body).to.be.an('object');
+            done();
+          });
+      });
+      it('should not delete a posted car AD if the carId is not an integer', (done) => {
+        chai.request(app)
+          .delete('/api/v1/car/df')
+          .end((err, res) => {
+            expect(res.status).to.be.equal(404);
+            expect(res.type).to.be.equal('application/json');
+            expect(res.body).to.be.an('object');
+            done();
+          });
+      });
+      it('should not delete a posted  AD if the catId is not in dataBase', (done) => {
+        chai.request(app)
+          .delete('/api/v1/car/100')
+          .end((err, res) => {
+            expect(res.status).to.be.equal(404);
+            expect(res.type).to.be.equal('application/json');
+            expect(res.body).to.be.an('object');
+            done();
+          });
+      });
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Have an Admin able to delete a posted car advert
### Description of Task to be completed?
Have the following endpoint working

`POST /api/v1/auth/signup`

`POST /api/v1/auth/signin`

`POST /api/v1/car/`

`POST /api/v1/order/`

`PATCH /api/v1/order/<:order_id>/price`

`PATCH /api/v1/car/<:car-id>/status`

`PATCH /api/v1/car/<:car-id>/price`

`GET /api/v1/car/<:car-id>/`

`GET /api/v1/car?status=available`

`GET /api/v1/car?status=available&min_price=value&max_price=value`

`DELETE /api/v1/car/<:car-id>/`
### How should this be manually tested?
After cloning the repo, cd into it and RUN `npm test`
* Using postman test the endpoint above with this header:

_key:_ Content-Type _value:_ application/x-www-form-urlencoded

### What is the relevant pivotal tracker stories?
#166152809