### PR TITLE
#166152880 Admin can view all posted ads whether sold or unsold (CRUD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AutoMart
 AutoMart is an online app that enables you to sell and/or buy cars.
 
-[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-admin-delete-advert-166152809)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-admin-delete-advert-166152809)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-admin-delete-advert-166152809) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
+[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-admin-view-all-adverts-166152880)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-admin-view-all-adverts-166152880)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-admin-view-all-adverts-166152880) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
 
 # Key Application Features
 

--- a/api/server/controllers/CarsController.js
+++ b/api/server/controllers/CarsController.js
@@ -67,6 +67,7 @@ class CarsController {
     const rQuery = req.query;
     const qLength = Object.keys(req.query).length;
     const validator = new Validator();
+    const isZero = qLength === 0;
     const isOne = qLength > 0 && qLength === 1;
     const isThree = qLength > 0 && qLength === 3;
 
@@ -102,6 +103,12 @@ class CarsController {
           data: unsoldCarsInPriceRange,
         });
       }
+    } else if (isZero) { // process request for admin view all car adverts
+      const allCars = carsService.getAllCars();
+      res.status(200).send({
+        status: 200,
+        data: allCars,
+      });
     } else {
       res.status(404).send({
         status: 404,

--- a/api/test/carsTest.js
+++ b/api/test/carsTest.js
@@ -273,9 +273,9 @@ describe('Cars Test', () => {
           done();
         });
     });
-    it('should not get all unsold cars when no status query string is sent', (done) => {
+    it('should not get all unsold/sold cars when query string is sent has more than 3 values', (done) => {
       chai.request(app)
-        .get('/api/v1/car?')
+        .get('/api/v1/car?a&b&c&d')
         .end((err, res) => {
           expect(res.status).to.be.equal(404);
           expect(res.type).to.be.equal('application/json');
@@ -338,6 +338,19 @@ describe('Cars Test', () => {
             done();
           });
       });
+    });
+  });
+
+  describe('GET /api/v1/car', () => {
+    it('should get all cars as admin both sold and unsold', (done) => {
+      chai.request(app)
+        .get('/api/v1/car')
+        .end((err, res) => {
+          expect(res.status).to.be.equal(200);
+          expect(res.type).to.be.equal('application/json');
+          expect(res.body).to.be.an('object');
+          done();
+        });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Have an Admin able to view all posted car adverts whether sold or unsold
### Description of Task to be completed?
Have the following endpoint working

`POST /api/v1/auth/signup`

`POST /api/v1/auth/signin`

`POST /api/v1/car/`

`POST /api/v1/order/`

`PATCH /api/v1/order/<:order_id>/price`

`PATCH /api/v1/car/<:car-id>/status`

`PATCH /api/v1/car/<:car-id>/price`

`GET /api/v1/car/<:car-id>/`

`GET /api/v1/car?status=available`

`GET /api/v1/car?status=available&min_price=value&max_price=value`

`DELETE /api/v1/car/<:car-id>/`

`GET /api/v1/car/`
### How should this be manually tested?
After cloning the repo, cd into it and RUN `npm test`
* Using postman test the endpoint above with this header:

_key:_ Content-Type _value:_ application/x-www-form-urlencoded

### What is the relevant pivotal tracker stories?
#166152880