### PR TITLE
#166395120 Add api documentation with swagger (docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AutoMart
 AutoMart is an online app that enables you to sell and/or buy cars.
 
-[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-view-cars-of-specific-manufacturer-166391992)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-view-cars-of-specific-manufacturer-166391992)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-view-cars-of-specific-manufacturer-166391992) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
+[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-add-api-documentation-166395120)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-add-api-documentation-166395120)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-add-api-documentation-166395120) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
 
 # Key Application Features
 

--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,9 @@
     "connect-multiparty": "^2.2.0",
     "dotenv": "^8.0.0",
     "express": "^4.17.0",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "swagger-jsdoc": "^3.2.9",
+    "swagger-ui-express": "^4.0.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -2,6 +2,8 @@
 import express from 'express';
 import logger from 'morgan';
 import bodyParser from 'body-parser';
+import swaggerUi from 'swagger-ui-express';
+import swaggerSpec from './swaggerDocs/config/swaggerDef';
 import usersRouter from './routes/usersRoutes';
 import carsRouter from './routes/carsRoutes';
 import ordersRouter from './routes/ordersRoutes';
@@ -12,6 +14,13 @@ const app = express();
 
 // Log request to console
 app.use(logger('dev'));
+
+// produce api documentation
+app.get('/swagger.json', (req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.send(swaggerSpec);
+});
+app.use('/api/v1/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // Parse incoming request data
 app.use(bodyParser.json());

--- a/api/server/swaggerDocs/a__users.yaml
+++ b/api/server/swaggerDocs/a__users.yaml
@@ -1,0 +1,151 @@
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        token:
+          $ref: '#/components/schemas/token'
+        id:
+          $ref: '#/components/schemas/userId'
+        firstname:
+          $ref: '#/components/schemas/firstname'
+        lastname:
+          $ref: '#/components/schemas/lastname'
+        email:
+          $ref: '#/components/schemas/email'
+        password:
+          $ref: '#/components/schemas/password'
+        address:
+          $ref: '#/components/schemas/address'
+        is_admin:
+          $ref: '#/components/schemas/is_admin'
+        phone_number:
+          $ref: '#/components/schemas/phone_number'
+    userSignup:
+      type: object
+      properties:
+        firstname:
+          $ref: '#/components/schemas/firstname'
+        lastname:
+          $ref: '#/components/schemas/lastname'
+        email:
+          $ref: '#/components/schemas/email'
+        password:
+          $ref: '#/components/schemas/password'
+        address:
+          $ref: '#/components/schemas/address'
+        phone_number:
+          $ref: '#/components/schemas/phone_number'
+    userSignin:
+      type: 'object'
+      properties:
+        email:
+          $ref: '#/components/schemas/email'
+        password:
+          $ref: '#/components/schemas/password'
+    token:
+      type: string
+      description: Authentication token
+      example: 45erkjherht45495783
+    userId:
+      type: integer
+      description: User identification number
+      example: '1234'
+    firstname:
+      type: string
+      description: User's first name
+      example: john
+    lastname:
+      type: string
+      description: User's last name
+      example: doe
+    email:
+      type: string
+      description: User email
+      example: example@mail.com
+    password:
+      type: string
+      description: User password
+      example: 1234hjkfg89
+    address:
+      type: string
+      description: User address
+      example: no 45 ikorodu road
+    is_admin:
+      type: boolean
+      description: if user is admin or not
+      example: 'true'
+    phone_number:
+      type: string
+      description: '07012345678'
+    
+
+paths:
+  /auth/signup:         # path of the user from your endpoint
+    post:              # endpoint request type (post request)
+      tags:
+        - User
+      description: 'Create a user account'
+      opperationId: 'addUser'
+      parameters: []
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/userSignup'
+        required: true
+      responses:
+        '201':
+          description: Response data after user signs up successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 201 success status code
+                    example: '201'
+                  data:
+                    $ref: '#/components/schemas/User'
+        '404':
+          description: Response for an unsuccessful registration
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /auth/signin:
+    post:
+      tags:
+        - User
+      description: 'login a user'
+      opperationId: getUser
+      parameters: []
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/userSignin'
+        required: true
+      responses:
+        '201':
+          description: Response data after user signs in successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 202 success status code
+                    example: '202'
+                  data:
+                    $ref: '#/components/schemas/User'

--- a/api/server/swaggerDocs/b__cars.yaml
+++ b/api/server/swaggerDocs/b__cars.yaml
@@ -1,0 +1,646 @@
+components:
+  schemas:
+    Car:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/carId'
+        onwer:
+          $ref: '#/components/schemas/owner'
+        created_on:
+          $ref: '#/components/schemas/created_on'
+        state:
+          $ref: '#/components/schemas/state'
+        status:
+          $ref: '#/components/schemas/status'
+        price:
+          $ref: '#/components/schemas/price'
+        title:
+          $ref: '#/components/schemas/title'
+        manufacturer:
+          $ref: '#/components/schemas/manufacturer'
+        model:
+          $ref: '#/components/schemas/model'
+        body_type:
+          $ref: '#/components/schemas/body_type'
+        photo:
+          $ref: '#/components/schemas/photo'
+    createAdvert:
+      type: object
+      properties:
+        owner:
+          $ref: '#/components/schemas/owner'
+        state:
+          $ref: '#/components/schemas/state'
+        status:
+          $ref: '#/components/schemas/status'
+        price:
+          $ref: '#/components/schemas/price'
+        title:
+          $ref: '#/components/schemas/title'
+        manufacturer:
+          $ref: '#/components/schemas/manufacturer'
+        model:
+          $ref: '#/components/schemas/model'
+        bodyType:
+          $ref: '#/components/schemas/body_type'
+        photo:
+          $ref: '#/components/schemas/image'
+    createdAdvert:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/carId'
+        email:
+          $ref: '#/components/schemas/email'
+        created_on:
+          $ref: '#/components/schemas/created_on'
+        manufacturer:
+          $ref: '#/components/schemas/manufacturer'
+        model:
+          $ref: '#/components/schemas/model'
+        body_type:
+          $ref: '#/components/schemas/body_type'
+        state:
+          $ref: '#/components/schemas/state'
+        status:
+          $ref: '#/components/schemas/status'
+        price:
+          $ref: '#/components/schemas/price'
+        title:
+          $ref: '#/components/schemas/title'
+        photo:
+          $ref: '#/components/schemas/photo'
+    updatedCarStatus:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/carId'
+        email:
+          $ref: '#/components/schemas/owner'
+        created_on:
+          $ref: '#/components/schemas/created_on'
+        manufacturer:
+          $ref: '#/components/schemas/manufacturer'
+        model:
+          $ref: '#/components/schemas/model'
+        price:
+          $ref: '#/components/schemas/price'
+        state:
+          $ref: '#/components/schemas/state'
+        status:
+          $ref: '#/components/schemas/status'
+    carId:
+      type: integer
+      description: Car identifaction number
+      example: '6'
+    owner:
+      type: integer
+      description: Car owner who posted the car advert
+      example: '12'
+    created_on:
+      type: string
+      format: date
+      description: The time the car advert was created
+      example: '1558620970335'
+    state:
+      type: string
+      description: Present state of the car if it's new or used
+      example: new/used
+    status:
+      type: string
+      description: Determines if an offer for the car has been accepted as it's no more available
+      example: available/sold - default is available
+    price:
+      type: float
+      description: Car price the owner wants to it for.
+      example: '120000000.00'
+    title:
+      type: string
+      description: title of the posted car advert
+      example: This is a brand new mercedes.
+    manufacturer:
+      type: string
+      description: The car makers
+      example: Mercedes
+    model:
+      type: string
+      description: Car model
+      example: mercedes brabus S550v
+    body_type:
+      type: string
+      description: Body type of the vehicle
+      example: Sedan, Truck, Hatchback...
+    photo:
+      type: string
+      description: Photo representation of the car on cloudinary
+      example: 'https://res.cloudinary.com/dya3r9cfe/image/upload/v1558624479/c9.jpg'
+    image:
+      type: string
+      format: binary
+      description: image file of the car
+paths:
+  /car:
+    post:
+      tags:
+        - Car
+      description: 'Create a car sale advert'
+      opperationId: addCar
+      parameters: []
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/createAdvert'
+        required: true
+      responses:
+        '201':
+          description: Response data after user creates car advert successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 201 success status code
+                    example: '201'
+                  data:
+                    $ref: '#/components/schemas/createdAdvert'
+        '404':
+          description: Response for an unsuccessful car creation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /car/car_id:
+    get:
+      tags:
+        - Car
+      description: 'get a specific car'
+      operationId: getACar
+      parameters:
+        - name: car_id
+          in: query
+          description: id of the specific car in database
+          required: true
+          schema:
+            $ref: '#/components/schemas/carId'
+      responses:
+        '200':
+          description: Response data that contains details about a car
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    $ref: '#/components/schemas/Car'
+        '404':
+          description: Response gotten when getting car is unsuccessful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+    delete:
+      tags:
+        - Car
+      description: Admin delete a specific car advert
+      operationId: deleteCar
+      parameters:
+        - name: car_id
+          in: query
+          description: id of the specific car in database
+          required: true
+          schema:
+            $ref: '#/components/schemas/carId'
+      responses:
+        '200':
+          description: Response data that contains success message
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    type: string
+                    description: string value with success message
+                    example: Car Ad successfully deleted
+        '404':
+          description: Response gotten when car id is invalid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /car/:
+    get:
+      tags:
+        - Car
+      description: Admin get a all cars
+      operationId: getCars
+      parameters: []
+      responses:
+        '200':
+          description: Response data that contains all cars
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Car'
+  /car?status=available:
+    get:
+      tags:
+        - Car
+      description: 'get a all unsold cars'
+      operationId: getAllUnsoldCars
+      parameters:
+        - name: status
+          in: query
+          description: available cars
+          required: true
+          schema:
+            type: string
+            enum: [available]
+            $ref: '#/components/schemas/status'
+      responses:
+        '200':
+          description: Response data that contains all available cars
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Car'
+        '404':
+          description: Error response when the query string and or its value is not correct
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /car?status=available&min_price=value&max_price=value:
+    get:
+      tags:
+        - Car
+      description: 'Get all unsold (available) cars within a price range'
+      operationId: getAllUnsoldCarsInPriceRange
+      parameters:
+        - name: status
+          in: query
+          description: available cars
+          required: true
+          schema:
+            type: string
+            enum: [available]
+            $ref: '#/components/schemas/status'
+        - name: min_price
+          in: query
+          description: user's desired lowest price of cars
+          required: true
+          schema:
+            $ref: '#/components/schemas/price'
+        - name: max_price
+          in: query
+          description: user's desired highest price of cars
+          required: true
+          schema:
+            $ref: '#/components/schemas/price'
+      responses:
+        '200':
+          description: Response data that contains all available cars with the user specified price range
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Car'
+        '404':
+          description: Error response when the query strings and or its value is not correct
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /car?status=available&state=new:
+    get:
+      tags:
+        - Car
+      description: Get all unsold new cars
+      operationId: getAllNewUnsoldCars
+      parameters:
+        - name: status
+          in: query
+          description: all available cars
+          required: true
+          schema:
+            type: string
+            enum: [available]
+            $ref: '#/components/schemas/status'
+        - name: state
+          in: query
+          description: all new cars
+          required: true
+          schema:
+            $ref: '#/components/schemas/state'
+      responses:
+        '200':
+          description: Response data that contains all available new cars
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Car'
+        '404':
+          description: Error response when the query strings and or its value is not correct
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /car?status=available&state=used:
+    get:
+      tags:
+        - Car
+      description: Get all unsold used cars
+      operationId: getAllUsedUnsoldCars
+      parameters:
+        - name: status
+          in: query
+          description: all available cars
+          required: true
+          schema:
+            type: string
+            enum: [available]
+            $ref: '#/components/schemas/status'
+        - name: state
+          in: query
+          description: all used cars
+          required: true
+          schema:
+            $ref: '#/components/schemas/state'
+      responses:
+        '200':
+          description: Response data that contains all available used cars
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Car'
+        '404':
+          description: Error response when the query strings and or its value is incorrect
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /car?status=available&manufacturer=value:
+    get:
+      tags:
+        - Car
+      description: Get all unsold used cars
+      operationId: getAllUnsoldCarsByManufacturer
+      parameters:
+        - name: status
+          in: query
+          description: all available cars
+          required: true
+          schema:
+            type: string
+            enum: [available]
+            $ref: '#/components/schemas/status'
+        - name: manufacturer
+          in: query
+          description: cars of a specific manufacturer
+          required: true
+          schema:
+            $ref: '#/components/schemas/manufacturer'
+      responses:
+        '200':
+          description: Response data that contains all available cars of a specific manufacturer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Car'
+        '404':
+          description: > 
+            Error response when the status (with its value) and 
+            manufacturer query string value is incorrect
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /car/car_id/status:
+    patch:
+      tags:
+        - Car
+      description: update a posted car avdert as sold
+      operationId: updateCarStatus
+      parameters:
+        - name: car_id
+          in: query
+          description: specific car id
+          required: true
+          schema:
+            $ref: '#/components/schemas/carId'
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: string
+              description: update car status to sold
+              example: sold
+        required: true
+      responses:
+        '200':
+          description: Response data that contains car detals with updated status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    $ref: '#/components/schemas/updatedCarStatus'
+        '404':
+          description: > 
+            Error response when an invaild or non existing car id and not the string "sold" is 
+            sent in request. 
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /car/car_id/price:
+    patch:
+      tags:
+        - Car
+      description: update the price of a car advert
+      operationId: updateCarPrice
+      parameters:
+        - name: car_id
+          in: query
+          description: specific car id
+          required: true
+          schema:
+            $ref: '#/components/schemas/carId'
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/price'
+        required: true
+      responses:
+        '200':
+          description: Response data that contains car detals with updated price
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    $ref: '#/components/schemas/updatedCarStatus'
+        '404':
+          description: > 
+            Error response when an invaild or non existing car id and/or an invalid price is 
+            sent in request. 
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'

--- a/api/server/swaggerDocs/c__orders.yaml
+++ b/api/server/swaggerDocs/c__orders.yaml
@@ -1,0 +1,164 @@
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/orderId'
+        buyer:
+          $ref: '#/components/schemas/buyer'
+        car_id:
+          $ref: '#/components/schemas/carId'
+        amount:
+          $ref: '#/components/schemas/orderStatus'
+        status:
+          $ref: '#/components/schemas/amount'
+    makeOrder:
+      type: object
+      properties:
+        buyer:
+          $ref: '#/components/schemas/buyer'
+        car_id:
+          $ref: '#/components/schemas/carId'
+        amount:
+          $ref: '#/components/schemas/orderStatus'
+    madeOrder:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/orderId'
+        buyer:
+          $ref: '#/components/schemas/buyer'
+        car_id:
+          $ref: '#/components/schemas/carId'
+        status:
+          $ref: '#/components/schemas/orderStatus'
+        price:
+          $ref: '#/components/schemas/price'
+        created_on:
+          $ref: '#/components/schemas/created_on'
+    updatedOrder:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/orderId'
+        car_id:
+          $ref: '#/components/schemas/carId'
+        status:
+          $ref: '#/components/schemas/orderStatus'
+        old_price_offered:
+          $ref: '#/components/schemas/amount'
+        new_price_offered:
+          type: float
+          example: '14500000.00'
+    orderId:
+      type: integer
+      description: Order identification number
+      example: '1'
+    buyer:
+      type: integer
+      decsription: id of user making the order
+      example: '4'
+    amount:
+      type: float
+      description: price the buyer is offering for the car
+      example: '14000000.00'
+    orderStatus:
+      type: string
+      description: current status of the order
+      example: pending, accepted or rejected
+paths:
+  /order:
+    post:
+      tags:
+        - Order
+      description: 'make a purchase order'
+      opperationId: makeOrder
+      parameters: []
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/makeOrder'
+        required: true
+      responses:
+        '201':
+          description: Response data after user makes a purchase order
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 201 success status code
+                    example: '201'
+                  data:
+                    $ref: '#/components/schemas/madeOrder'
+        '404':
+          description: > 
+            Response for an unsuccessful purchase due to 
+            incorrect url or any/all the required fields is not filled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'
+  /order/order_id/price:
+    patch:
+      tags:
+        - Order
+      description: buyer updates the price of their purchase when the status is still "pending"
+      operationId: updateOrder
+      parameters:
+        - name: order_id
+          in: query
+          description: order id
+          required: true
+          schema:
+            $ref: '#/components/schemas/orderId'
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: float
+              description: buyer's new price for the car
+              example: '14500000.00'
+        required: true
+      responses:
+        '200':
+          description: Response data after buyer updates the price of the order
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 200 success status code
+                    example: '200'
+                  data:
+                    $ref: '#/components/schemas/updatedOrder'
+        '404':
+          description: > 
+            Response for an unsuccessful price due to 
+            incorrect url or the new price entered and/or order id parameter is not valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'

--- a/api/server/swaggerDocs/config/swaggerDef.js
+++ b/api/server/swaggerDocs/config/swaggerDef.js
@@ -1,0 +1,25 @@
+/* eslint-disable linebreak-style */
+import path from 'path';
+import swaggerJSDoc from 'swagger-jsdoc';
+
+const swaggerDefinition = {
+  openapi: '3.0.1',
+  info: {
+    title: 'REST API Documentation for AutoMart', // Title of the documentation
+    version: '1.0.0', // Version of the app
+    description: 'This documentation has all the datails on how to consume this api such as'
+    + ' registering an account, creating a car advert and more.'
+    + ' Note: all endpoints should be prefixed with "/api/v1/"', // short description of the app
+  },
+};
+const dir = path.join(__dirname, '..', '/');
+
+// options for the swagger docs
+const options = {
+  // import swaggerDefinitions
+  swaggerDefinition,
+  // path to the API docs
+  apis: [`${dir}/**/*.yaml`],
+};
+// initialize swagger-jsdoc
+export default swaggerJSDoc(options);

--- a/api/server/swaggerDocs/d__flags.yaml
+++ b/api/server/swaggerDocs/d__flags.yaml
@@ -1,0 +1,90 @@
+components:
+  schemas:
+    Flags:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/flagId'
+        car_id:
+          $ref: '#/components/schemas/carId'
+        created_on:
+          $ref: '#/components/schemas/created_on'
+        reason:
+          $ref: '#/components/schemas/reason'
+        description:
+          $ref: '#/components/schemas/description'
+    reportAdvert:
+      type: object
+      properties:
+        car_id:
+          $ref: '#/components/schemas/carId'
+        reason:
+          $ref: '#/components/schemas/reason'
+        description:
+          $ref: '#/components/schemas/description'
+    flagedReport:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/flagId'
+        car_id:
+          $ref: '#/components/schemas/carId'
+        reason:
+          $ref: '#/components/schemas/reason'
+        description:
+          $ref: '#/components/schemas/description'
+    flagId:
+      type: integer
+      description: Flag identification number
+      example: '9'
+    reason:
+      type: string
+      description: reason for the flag
+      example: pricing, weird demands, etc
+    description:
+      type: string
+      description: a descriptive report about the advert
+      example: The ad has a mercedes brabus g-wagon sold for 1 million naira
+paths:
+  /flag:
+    post:
+      tags:
+        - Flag
+      description: report a suspected or fraudulent advert
+      opperationId: reportAdvert
+      parameters: []
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/reportAdvert'
+        required: true
+      responses:
+        '201':
+          description: Response data after reporting an advert
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 201 success status code
+                    example: '201'
+                  data:
+                    $ref: '#/components/schemas/flagedReport'
+        '404':
+          description: > 
+            Response when the report advert request is unsuccessful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 404 error status code
+                    example: '404'
+                  error: 
+                    type: object/string
+                    example: 'necessary error message'

--- a/api/test/indexTest.js
+++ b/api/test/indexTest.js
@@ -1,0 +1,23 @@
+/* eslint-disable linebreak-style */
+/* eslint-disable import/no-extraneous-dependencies */
+/* global describe:true, it:true, */
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from './app';
+
+chai.use(chaiHttp);
+
+describe('Index Test', () => {
+  describe('GET /swagger.json', () => {
+    it('should return a json object of the api documentation', (done) => {
+      chai.request(app)
+        .get('/swagger.json')
+        .end((err, res) => {
+          expect(res.status).to.be.eql(200);
+          expect(res.type).to.be.equal('application/json');
+          expect(res.body).to.be.an('object');
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Have a user able to view the api documentation of the api
### Description of Task to be completed?
Have the following endpoint working

`POST /api/v1/auth/signup`

`POST /api/v1/auth/signin`

`POST /api/v1/car/`

`POST /api/v1/order/`

`PATCH /api/v1/order/<:order_id>/price`

`PATCH /api/v1/car/<:car-id>/status`

`PATCH /api/v1/car/<:car-id>/price`

`GET /api/v1/car/<:car-id>/`

`GET /api/v1/car?status=available`

`GET /api/v1/car?status=available&min_price=value&max_price=value`

`DELETE /api/v1/car/<:car-id>/`

`GET /api/v1/car/`

`POST /api/v1/flag/`

`GET /api/v1/car?status=available&state=used`

`GET /api/v1/car?status=available&state=new`

`GET /api/v1/car?status=available&manufacturer=value`

`GET /api/v1/api-docs`
### How should this be manually tested?
After cloning the repo, cd into it and RUN `npm test`
* Using postman test the endpoint above with this header:

_key:_ Content-Type _value:_ application/x-www-form-urlencoded

### What is the relevant pivotal tracker stories?
#166395120