### PR TITLE
#166715888 Admin should be able to view all posted ads whether sold or unsold (CRUD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AutoMart
 AutoMart is an online app that enables you to sell and/or buy cars.
 
-[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-admin-delete-advert-166715876)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-admin-delete-advert-166715876)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-admin-delete-advert-166715876) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
+[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-admin-view-all-car-ads-166715888)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-admin-view-all-car-ads-166715888)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-admin-view-all-car-ads-166715888) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
 
 # Key Application Features
 

--- a/api/server/controllers/CarsController.js
+++ b/api/server/controllers/CarsController.js
@@ -45,6 +45,13 @@ class CarsController {
 
   async getCars(req, res) {
     const rQuery = req.query;
+    if (req.qLength === 0) {
+      const result = await Cars.getAllCars();
+      res.status(200).send({
+        status: 200,
+        data: result.rows,
+      });
+    }
     if (req.qLength === 1) {
       const result = await Cars.getCarsByStatusAvailable();
       res.status(200).send({

--- a/api/server/middlewares/CarsMiddleware.js
+++ b/api/server/middlewares/CarsMiddleware.js
@@ -73,9 +73,13 @@ export const validateViewACar = async (req, res, next) => {
 export const validateViewCars = (req, res, next) => {
   const rQuery = req.query;
   const qLength = Object.keys(req.query).length;
+  const isZero = qLength === 0;
   const isOne = qLength > 0 && qLength === 1;
   const isThree = qLength > 0 && qLength === 3;
-  if (isOne) {
+  if (isZero) {
+    req.qLength = 0;
+    next();
+  } else if (isOne) {
     const result = Validator.validateViewUnsoldCarsQuery(rQuery.status);
     if (result.error) {
       res.status(400).send(Validator.Response());

--- a/api/server/models/Cars.js
+++ b/api/server/models/Cars.js
@@ -63,6 +63,12 @@ class Cars {
     return result;
   }
 
+  async getAllCars() {
+    const queryString = 'SELECT * FROM cars;';
+    const result = await db.query(queryString);
+    return result;
+  }
+
   async getCarsByStatusAvailable() {
     const queryString = 'SELECT * FROM cars WHERE status = \'available\';';
     const result = db.query(queryString);

--- a/api/test/d__carsTest.js
+++ b/api/test/d__carsTest.js
@@ -345,4 +345,17 @@ describe('Cars Test', () => {
         });
     });
   });
+
+  describe('GET /api/v1/car', () => {
+    it('should get all cars as admin both sold and unsold', (done) => {
+      chai.request(app)
+        .get('/api/v1/car')
+        .end((err, res) => {
+          expect(res.status).to.be.equal(200);
+          expect(res.type).to.be.equal('application/json');
+          expect(res.body).to.be.an('object');
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Have an admin able to view all cars
### Description of Task to be completed?
Have the following endpoints working

`POST /api/v1/auth/signup`

`POST /api/v1/auth/signin`

`POST /api/v1/car`

`POST /api/v1/order/`

`PATCH /api/v1/order/<:order-id>/price`

`PATCH /api/v1/car/<:car-id>/status`

`PATCH /api/v1/car/<:car-id>/price`

`GET /api/v1/car/<:car-id>/`

`GET /api/v1/car?status=available`

`GET /api/v1/car?status=available&min_price=XXXValue &max_price=XXXValue`

`DELETE /api/v1/car/<:car_id>/`

`GET /api/v1/car/`

### How should this be manually tested?
After cloning the repo, cd into it and RUN `npm test`
* Using postman test the endpoint above with this header:

_key:_ Content-Type _value:_ application/x-www-form-urlencoded

### Any background context you want to provide?
Data is persisted with postgres database

### What is the relevant pivotal tracker stories?
#166715888