### PR TITLE
#166716028 User should be able to view all unsold cars of a specific manufacturer (CRUD)

### DIFF
--- a/api/server/controllers/CarsController.js
+++ b/api/server/controllers/CarsController.js
@@ -58,7 +58,11 @@ class CarsController {
         data: result.rows,
       });
     } else if (req.qLength === 2) {
-      const result = await Cars.getCarsByStatusAndState('state', rQuery.state);
+      let result = '';
+      if (rQuery.state) { result = await Cars.getCarsByStatusAndState('state', rQuery.state); }
+      if (rQuery.manufacturer) {
+        result = await Cars.getCarsByStatusAndManufacturer('manufacturer', rQuery.manufacturer);
+      }
       res.status(200).send({
         status: 200,
         data: result.rows,

--- a/api/server/middlewares/CarsMiddleware.js
+++ b/api/server/middlewares/CarsMiddleware.js
@@ -97,6 +97,16 @@ export const validateViewCars = (req, res, next) => {
         req.qLength = 2;
         next();
       }
+    } else if (rQuery.status && rQuery.manufacturer) {
+      const result = Validator.validateViewUnsoldCarsByManufacturer(
+        rQuery.status, rQuery.manufacturer,
+      );
+      if (result.error) {
+        res.status(400).send(Validator.Response());
+      } else {
+        req.qLength = 2;
+        next();
+      }
     } else res.status(400).send({ status: 400, error: 'The query string (with its value) is not valid.' });
   } else if (isThree && rQuery.min_price && rQuery.max_price) {
     const result = Validator.validateViewUnsoldCarsInPriceRange(

--- a/api/server/middlewares/validators/ValidateCar.js
+++ b/api/server/middlewares/validators/ValidateCar.js
@@ -74,6 +74,13 @@ class ValidateCar extends Validator {
     return ValidateCar.getErrorMessage();
   }
 
+  static validateViewUnsoldCarsByManufacturer(status, manufacturer) {
+    ValidateCar.refresh();
+    ValidateCar.isValidStatusQuery(status, 'status');
+    ValidateCar.validateString(manufacturer, 'manufacturer');
+    return ValidateCar.getErrorMessage();
+  }
+
   static isValidOwner(owner, type) {
     ValidateCar.validateInt(owner, type);
   }

--- a/api/server/models/Cars.js
+++ b/api/server/models/Cars.js
@@ -89,6 +89,13 @@ class Cars {
     return result;
   }
 
+  async getCarsByStatusAndManufacturer(field, manufacturer) {
+    const queryString = `SELECT * FROM cars WHERE status = 'available'
+      AND ${field} ~* '${manufacturer}';`;
+    const result = db.query(queryString);
+    return result;
+  }
+
   async updater(carId, field, value) {
     const car = await this.getCarById(carId);
     const owner = await this.getCarOwner(car.rows[0].owner);

--- a/api/test/d__carsTest.js
+++ b/api/test/d__carsTest.js
@@ -391,4 +391,27 @@ describe('Cars Test', () => {
         });
     });
   });
+
+  describe('GET /api/v1/car?status=available&manufacturer=value', () => {
+    it('should get all unsold cars from a specific manufacturer', (done) => {
+      chai.request(app)
+        .get('/api/v1/car?status=available&manufacturer=toyota')
+        .end((err, res) => {
+          expect(res.status).to.be.equal(200);
+          expect(res.type).to.be.equal('application/json');
+          expect(res.body).to.be.an('object');
+          done();
+        });
+    });
+    it('should not get all unsold cars of a specific manufacturer', (done) => {
+      chai.request(app)
+        .get('/api/v1/car?status=availables&manufacturer=toyota')
+        .end((err, res) => {
+          expect(res.status).to.be.equal(400);
+          expect(res.type).to.be.equal('application/json');
+          expect(res.body).to.be.an('object');
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Have a user view all cars of a specific manufacturer
### Description of Task to be completed?
Have the following endpoints working

`POST /api/v1/auth/signup`

`POST /api/v1/auth/signin`

`POST /api/v1/car`

`POST /api/v1/order/`

`PATCH /api/v1/order/<:order-id>/price`

`PATCH /api/v1/car/<:car-id>/status`

`PATCH /api/v1/car/<:car-id>/price`

`GET /api/v1/car/<:car-id>/`

`GET /api/v1/car?status=available`

`GET /api/v1/car?status=available&min_price=XXXValue &max_price=XXXValue`

`DELETE /api/v1/car/<:car_id>/`

`GET /api/v1/car/`

`GET /api/v1/car?status=available&state=new`

`GET /api/v1/car?status=available&state=used`

`POST /api/v1/flag`

 `GET /api/v1/car?status=available&manufacturer=value`

### How should this be manually tested?
After cloning the repo, cd into it and RUN `npm test`
* Using postman test the endpoint above with this header:

_key:_ Content-Type _value:_ application/x-www-form-urlencoded

### Any background context you want to provide?
Data is persisted with postgres database

### What is the relevant pivotal tracker stories?
#166716028