### PR TITLE
#166855506 User should be able to view the api documentation (CRUD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AutoMart
 AutoMart is an online app that enables you to sell and/or buy cars.
 
-[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-add-jwt-authentication-166835641)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-add-jwt-authentication-166835641)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-add-jwt-authentication-166835641) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
+[![Build Status](https://travis-ci.com/UggoPrince/AutoMart.svg?branch=ft-api-documentation-166855506)](https://travis-ci.com/UggoPrince/AutoMart) [![Coverage Status](https://coveralls.io/repos/github/UggoPrince/AutoMart/badge.svg?branch=ft-api-documentation-166855506)](https://coveralls.io/github/UggoPrince/AutoMart?branch=ft-api-documentation-166855506) [![Test Coverage](https://api.codeclimate.com/v1/badges/57c9772eeae7b66be027/test_coverage)](https://codeclimate.com/github/UggoPrince/AutoMart/test_coverage)
 
 # Key Application Features
 

--- a/api/server/middlewares/CarsMiddleware.js
+++ b/api/server/middlewares/CarsMiddleware.js
@@ -28,7 +28,7 @@ export const validateUpdateCarStatus = async (req, res, next) => {
   } else if (!await CarChecker.checkId(carId)) {
     res.status(404).send({
       status: 404,
-      error: `Car with id (${carId}) do not exist.`,
+      error: `Car with id (${carId}) does not exist.`,
     });
   } else {
     req.body.email = req.token.email;
@@ -45,7 +45,7 @@ export const validateUpdateCarPrice = async (req, res, next) => {
   } else if (!await CarChecker.checkId(carId)) {
     res.status(404).send({
       status: 404,
-      error: `Car with id (${carId}) do not exist.`,
+      error: `Car with id (${carId}) does not exist.`,
     });
   } else {
     req.body.email = req.token.email;
@@ -141,7 +141,7 @@ export const validateDeleteCar = async (req, res, next) => {
       status: 403, error: 'You are not an admin. Only admin are allowed to delete an Advert',
     });
   } else if (!await CarChecker.checkId(carId)) {
-    res.status(404).send({ status: 404, error: `Car with id (${carId}) do not exist.` });
+    res.status(404).send({ status: 404, error: `Car with id (${carId}) does not exist.` });
   } else {
     next();
   }

--- a/api/server/middlewares/FlagsMiddleware.js
+++ b/api/server/middlewares/FlagsMiddleware.js
@@ -13,7 +13,7 @@ const validateReportAdvert = async (req, res, next) => {
   } else if (!await FlagChecker.checkFlaggedCar(carId)) {
     res.status(404).send({
       status: 404,
-      error: `Car with id (${carId}) do not exist.`,
+      error: `Car with id (${carId}) does not exist.`,
     });
   } else {
     next();

--- a/api/server/middlewares/OrdersMiddleware.js
+++ b/api/server/middlewares/OrdersMiddleware.js
@@ -13,7 +13,7 @@ export const validatePurchaseOrder = async (req, res, next) => {
     const car = await OrderChecker.checkOrderedCar(carId);
     if (car.error) {
       error = true;
-      errorMessage.carId = `Car with id (${carId}) do not exist.`;
+      errorMessage.carId = `Car with id (${carId}) does not exist.`;
     }
     if (error) {
       res.status(404).send({
@@ -39,7 +39,7 @@ export const validateUpdateOrderPrice = async (req, res, next) => {
     if (order.error) {
       res.status(404).send({
         status: 404,
-        error: `Order with id (${orderId}) do not exist.`,
+        error: `Order with id (${orderId}) does not exist.`,
       });
     } else {
       req.body.amount = order.data.amount;

--- a/api/server/swaggerDocs/a__users.yaml
+++ b/api/server/swaggerDocs/a__users.yaml
@@ -46,7 +46,7 @@ components:
     token:
       type: string
       description: Authentication token
-      example: 45erkjherht45495783
+      example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NCwiZW1haWwiOiJ0aG9ueUBnbWFpbC5jb20iLCJpc0FkbWluIjpmYWxzZSwiaWF0IjoxNTYxMTYyMTY0LCJleHAiOjE1NjEyNDg1NjR9.jx2qbXyui03Dhb9F8iwwbMel9LMYIShLYr5Y5y94BtU
     userId:
       type: integer
       description: User identification number
@@ -108,7 +108,7 @@ paths:
                     example: '201'
                   data:
                     $ref: '#/components/schemas/User'
-        '404':
+        '400':
           description: Response for an unsuccessful registration
           content:
             application/json:
@@ -118,10 +118,10 @@ paths:
                   status:
                     type: integer
                     description: 404 error status code
-                    example: '404'
+                    example: '400'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Invalid email'
   /auth/signin:
     post:
       tags:
@@ -149,3 +149,17 @@ paths:
                     example: '202'
                   data:
                     $ref: '#/components/schemas/User'
+        '404':
+          description: Response for an unsuccessful login
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 400 error status code
+                    example: '400'
+                  error: 
+                    type: object/string
+                    example: 'Invalid email/password'

--- a/api/server/swaggerDocs/b__cars.yaml
+++ b/api/server/swaggerDocs/b__cars.yaml
@@ -28,8 +28,6 @@ components:
     createAdvert:
       type: object
       properties:
-        owner:
-          $ref: '#/components/schemas/owner'
         state:
           $ref: '#/components/schemas/state'
         status:
@@ -71,13 +69,20 @@ components:
           $ref: '#/components/schemas/title'
         photo:
           $ref: '#/components/schemas/photo'
+    updateCarStatus:
+      type: object
+      properties:
+        newStatus:
+          type: string
+          description: update car status to sold
+          example: sold
     updatedCarStatus:
       type: object
       properties:
         id:
           $ref: '#/components/schemas/carId'
         email:
-          $ref: '#/components/schemas/owner'
+          $ref: '#/components/schemas/email'
         created_on:
           $ref: '#/components/schemas/created_on'
         manufacturer:
@@ -90,6 +95,13 @@ components:
           $ref: '#/components/schemas/state'
         status:
           $ref: '#/components/schemas/status'
+    updateCarPrice:
+      type: object
+      properties:
+        newPrice:
+          type: float
+          description: update car price to a new price
+          example: '18000000'
     carId:
       type: integer
       description: Car identifaction number
@@ -146,7 +158,13 @@ paths:
         - Car
       description: 'Create a car sale advert'
       opperationId: addCar
-      parameters: []
+      parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
       requestBody:
         content:
           'application/json':
@@ -167,7 +185,7 @@ paths:
                     example: '201'
                   data:
                     $ref: '#/components/schemas/createdAdvert'
-        '404':
+        '400':
           description: Response for an unsuccessful car creation
           content:
             application/json:
@@ -176,11 +194,11 @@ paths:
                 properties:
                   status:
                     type: integer
-                    description: 404 error status code
-                    example: '404'
+                    description: 400 error status code
+                    example: '400'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Invalid Price'
   /car/car_id:
     get:
       tags:
@@ -188,6 +206,12 @@ paths:
       description: 'get a specific car'
       operationId: getACar
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: car_id
           in: query
           description: id of the specific car in database
@@ -208,8 +232,22 @@ paths:
                     example: '200'
                   data:
                     $ref: '#/components/schemas/Car'
+        '400':
+          description: Response gotten when car is not valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 400 error status code
+                    example: '400'
+                  error: 
+                    type: object/string
+                    example: 'Invalid carId'
         '404':
-          description: Response gotten when getting car is unsuccessful
+          description: Response gotten when car does not exit in database
           content:
             application/json:
               schema:
@@ -221,13 +259,19 @@ paths:
                     example: '404'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Car with id (carId) does not exist.'
     delete:
       tags:
         - Car
       description: Admin delete a specific car advert
       operationId: deleteCar
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: car_id
           in: query
           description: id of the specific car in database
@@ -250,8 +294,36 @@ paths:
                     type: string
                     description: string value with success message
                     example: Car Ad successfully deleted
+        '403':
+          description: Response gotten when the user is not an admin
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 403 error status code
+                    example: '403'
+                  error: 
+                    type: object/string
+                    example: 'You are not an admin. Only admin are allowed to delete an Advert'
+        '400':
+          description: Response gotten when car is not valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 400 error status code
+                    example: '400'
+                  error: 
+                    type: object/string
+                    example: 'Invalid carId'
         '404':
-          description: Response gotten when car id is invalid
+          description: Response gotten when car id does not exist in database
           content:
             application/json:
               schema:
@@ -263,14 +335,20 @@ paths:
                     example: '404'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Car with id (carId) does not exist.'
   /car/:
     get:
       tags:
         - Car
       description: Admin get a all cars
       operationId: getCars
-      parameters: []
+      parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
       responses:
         '200':
           description: Response data that contains all cars
@@ -287,6 +365,20 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Car'
+        '403':
+          description: Response gotten when the user is not an admin
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 403 error status code
+                    example: '403'
+                  error: 
+                    type: object/string
+                    example: 'You are not an admin. Only admins are allowed to view both sold and unsold cars.'
   /car?status=available:
     get:
       tags:
@@ -294,6 +386,12 @@ paths:
       description: 'get a all unsold cars'
       operationId: getAllUnsoldCars
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: status
           in: query
           description: available cars
@@ -318,7 +416,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Car'
-        '404':
+        '400':
           description: Error response when the query string and or its value is not correct
           content:
             application/json:
@@ -328,10 +426,10 @@ paths:
                   status:
                     type: integer
                     description: 404 error status code
-                    example: '404'
+                    example: '400'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'The status query string must be [ ?status=available ].'
   /car?status=available&min_price=value&max_price=value:
     get:
       tags:
@@ -339,6 +437,12 @@ paths:
       description: 'Get all unsold (available) cars within a price range'
       operationId: getAllUnsoldCarsInPriceRange
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: status
           in: query
           description: available cars
@@ -375,7 +479,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Car'
-        '404':
+        '400':
           description: Error response when the query strings and or its value is not correct
           content:
             application/json:
@@ -384,11 +488,11 @@ paths:
                 properties:
                   status:
                     type: integer
-                    description: 404 error status code
-                    example: '404'
+                    description: 400 error status code
+                    example: '400'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Invalid Price.'
   /car?status=available&state=new:
     get:
       tags:
@@ -396,6 +500,12 @@ paths:
       description: Get all unsold new cars
       operationId: getAllNewUnsoldCars
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: status
           in: query
           description: all available cars
@@ -426,7 +536,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Car'
-        '404':
+        '400':
           description: Error response when the query strings and or its value is not correct
           content:
             application/json:
@@ -435,11 +545,11 @@ paths:
                 properties:
                   status:
                     type: integer
-                    description: 404 error status code
-                    example: '404'
+                    description: 400 error status code
+                    example: '400'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Invalid state. Must be [ new ] or [ used ].'
   /car?status=available&state=used:
     get:
       tags:
@@ -447,6 +557,12 @@ paths:
       description: Get all unsold used cars
       operationId: getAllUsedUnsoldCars
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: status
           in: query
           description: all available cars
@@ -477,7 +593,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Car'
-        '404':
+        '400':
           description: Error response when the query strings and or its value is incorrect
           content:
             application/json:
@@ -486,11 +602,11 @@ paths:
                 properties:
                   status:
                     type: integer
-                    description: 404 error status code
-                    example: '404'
+                    description: 400 error status code
+                    example: '400'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Invalid state. Must be [ new ] or [ used ].'
   /car?status=available&manufacturer=value:
     get:
       tags:
@@ -498,6 +614,12 @@ paths:
       description: Get all unsold used cars
       operationId: getAllUnsoldCarsByManufacturer
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: status
           in: query
           description: all available cars
@@ -528,7 +650,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Car'
-        '404':
+        '400':
           description: > 
             Error response when the status (with its value) and 
             manufacturer query string value is incorrect
@@ -539,11 +661,11 @@ paths:
                 properties:
                   status:
                     type: integer
-                    description: 404 error status code
-                    example: '404'
+                    description: 400 error status code
+                    example: '400'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'The status query string must be [ ?status=available ].'
   /car/car_id/status:
     patch:
       tags:
@@ -551,6 +673,12 @@ paths:
       description: update a posted car avdert as sold
       operationId: updateCarStatus
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: car_id
           in: query
           description: specific car id
@@ -561,9 +689,7 @@ paths:
         content:
           'application/json':
             schema:
-              type: string
-              description: update car status to sold
-              example: sold
+              $ref: '#/components/schemas/updateCarStatus'
         required: true
       responses:
         '200':
@@ -581,8 +707,7 @@ paths:
                     $ref: '#/components/schemas/updatedCarStatus'
         '404':
           description: > 
-            Error response when an invaild or non existing car id and not the string "sold" is 
-            sent in request. 
+            Error response when an invaild or non existing car id sent in request. 
           content:
             application/json:
               schema:
@@ -594,7 +719,22 @@ paths:
                     example: '404'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Car with id (carId) does not exist.'
+        '400':
+          description: > 
+            Error response when a different string instead of 'sold' is sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 400 error status code
+                    example: '400'
+                  error: 
+                    type: object/string
+                    example: 'Invalid newStatus. Must be changed to [ sold ] in order to update the status.'
   /car/car_id/price:
     patch:
       tags:
@@ -602,6 +742,12 @@ paths:
       description: update the price of a car advert
       operationId: updateCarPrice
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: car_id
           in: query
           description: specific car id
@@ -612,7 +758,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/price'
+              $ref: '#/components/schemas/updateCarPrice'
         required: true
       responses:
         '200':
@@ -643,4 +789,19 @@ paths:
                     example: '404'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Car with id (carId) does not exist.'
+        '400':
+          description: > 
+            Error response when an invaild price is sent 
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 400 error status code
+                    example: '400'
+                  error: 
+                    type: object/string
+                    example: 'Car with id (carId) do not exist.'

--- a/api/server/swaggerDocs/c__orders.yaml
+++ b/api/server/swaggerDocs/c__orders.yaml
@@ -16,27 +16,36 @@ components:
     makeOrder:
       type: object
       properties:
-        buyer:
-          $ref: '#/components/schemas/buyer'
         car_id:
           $ref: '#/components/schemas/carId'
         amount:
-          $ref: '#/components/schemas/orderStatus'
+          type: float
+          description: Price the buyer is offering.
+          example: '140000000.00'
     madeOrder:
       type: object
       properties:
         id:
           $ref: '#/components/schemas/orderId'
-        buyer:
-          $ref: '#/components/schemas/buyer'
         car_id:
           $ref: '#/components/schemas/carId'
+        created_on:
+          $ref: '#/components/schemas/created_on'
         status:
           $ref: '#/components/schemas/orderStatus'
         price:
           $ref: '#/components/schemas/price'
-        created_on:
-          $ref: '#/components/schemas/created_on'
+        price_offered:
+          type: float
+          description: Price the buyer is offering.
+          example: '140000000.00'
+    updateOrder:
+      type: object
+      properties:
+        newAmount:
+          type: float
+          description: Pew price the buyer is offering.
+          example: '14500000.00'
     updatedOrder:
       type: object
       properties:
@@ -50,7 +59,8 @@ components:
           $ref: '#/components/schemas/amount'
         new_price_offered:
           type: float
-          example: '14500000.00'
+          description: New Price the buyer want to buy the car
+          example: '11500000.00'
     orderId:
       type: integer
       description: Order identification number
@@ -74,7 +84,13 @@ paths:
         - Order
       description: 'make a purchase order'
       opperationId: makeOrder
-      parameters: []
+      parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
       requestBody:
         content:
           'application/json':
@@ -95,10 +111,24 @@ paths:
                     example: '201'
                   data:
                     $ref: '#/components/schemas/madeOrder'
+        '400':
+          description: > 
+            Response when the amount offered is not a float
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 400 error status code
+                    example: '400'
+                  error: 
+                    type: object/string
+                    example: 'Invalid amount.'
         '404':
           description: > 
-            Response for an unsuccessful purchase due to 
-            incorrect url or any/all the required fields is not filled
+            Response for an unsuccessful purchase when carId does not exist
           content:
             application/json:
               schema:
@@ -110,7 +140,7 @@ paths:
                     example: '404'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Car with id (6) does not exist.'
   /order/order_id/price:
     patch:
       tags:
@@ -118,6 +148,12 @@ paths:
       description: buyer updates the price of their purchase when the status is still "pending"
       operationId: updateOrder
       parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
         - name: order_id
           in: query
           description: order id
@@ -128,9 +164,7 @@ paths:
         content:
           'application/json':
             schema:
-              type: float
-              description: buyer's new price for the car
-              example: '14500000.00'
+              $ref: '#/components/schemas/updateOrder'
         required: true
       responses:
         '200':
@@ -146,10 +180,24 @@ paths:
                     example: '200'
                   data:
                     $ref: '#/components/schemas/updatedOrder'
+        '400':
+          description: > 
+            Response when the new amount is not a float
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 400 error status code
+                    example: '400'
+                  error: 
+                    type: object/string
+                    example: 'Invalid newAmount'
         '404':
           description: > 
-            Response for an unsuccessful price due to 
-            incorrect url or the new price entered and/or order id parameter is not valid
+            Response when the order does not exist
           content:
             application/json:
               schema:
@@ -161,4 +209,4 @@ paths:
                     example: '404'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Order with id (orderId) does not exist.'

--- a/api/server/swaggerDocs/d__flags.yaml
+++ b/api/server/swaggerDocs/d__flags.yaml
@@ -52,7 +52,13 @@ paths:
         - Flag
       description: report a suspected or fraudulent advert
       opperationId: reportAdvert
-      parameters: []
+      parameters:
+        - name: authentication
+          in: header
+          description: authentication header with jwt token
+          required: true
+          schema:
+            $ref: '#/components/schemas/token'
       requestBody:
         content:
           'application/json':
@@ -73,9 +79,24 @@ paths:
                     example: '201'
                   data:
                     $ref: '#/components/schemas/flagedReport'
+        '400':
+          description: > 
+            Response when one of the form input data is not valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: 400 error status code
+                    example: '400'
+                  error: 
+                    type: object/string
+                    example: 'Invalid Reason.'
         '404':
           description: > 
-            Response when the report advert request is unsuccessful
+            Response when the car being reported does not exist
           content:
             application/json:
               schema:
@@ -87,4 +108,4 @@ paths:
                     example: '404'
                   error: 
                     type: object/string
-                    example: 'necessary error message'
+                    example: 'Car with id (6) does not exist.'


### PR DESCRIPTION
### What does this PR do?
Have a able to view the api documentation
### Description of Task to be completed?
Have the following endpoints working

`POST /api/v1/auth/signup`

`POST /api/v1/auth/signin`

`POST /api/v1/car`

`POST /api/v1/order/`

`PATCH /api/v1/order/<:order-id>/price`

`PATCH /api/v1/car/<:car-id>/status`

`PATCH /api/v1/car/<:car-id>/price`

`GET /api/v1/car/<:car-id>/`

`GET /api/v1/car?status=available`

`GET /api/v1/car?status=available&min_price=XXXValue &max_price=XXXValue`

`DELETE /api/v1/car/<:car_id>/`

`GET /api/v1/car/`

`GET /api/v1/car?status=available&state=new`

`GET /api/v1/car?status=available&state=used`

`POST /api/v1/flag`

 `GET /api/v1/car?status=available&manufacturer=value`

`GET /api/v1/api-docs`

### How should this be manually tested?
After cloning the repo, cd into it and RUN `npm test`
* Using postman test the endpoint above with this header:

_key:_ Content-Type _value:_ application/x-www-form-urlencoded

* To test authentication, add a header that contains the token

_key:_ Authentication _Value:_ token

### Any background context you want to provide?
Data is persisted with postgres database

### What is the relevant pivotal tracker stories?
#166855506